### PR TITLE
Update workflow to use Cronitor for monitoring

### DIFF
--- a/.github/workflows/cronitor
+++ b/.github/workflows/cronitor
@@ -1,0 +1,20 @@
+name: Cronitor Monitoring Relay
+
+on:
+  workflow_run:
+    workflows: ['*']
+    types: [requested,completed]
+
+jobs:
+  send-telemetry:
+    runs-on: ubuntu-latest
+    name: Send Telemetry
+    steps:
+      - name: Send execution details to the Cronitor for Github Actions agent
+        uses: cronitorio/monitor-github-actions@v7
+        with:
+          event: ${{ toJSON(github.event) }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cronitor_key: ${{ secrets.CRONITOR_API_KEY }}
+          cronitor_group: actions
+          cronitor_notify: default


### PR DESCRIPTION
Replaced Node.js package publishing workflow with Cronitor monitoring relay.